### PR TITLE
Feature/#5 fnt

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
-locals_without_parens = [deft: :*, defpt: :*, defmacrot: :*, defmacropt: :*]
+locals_without_parens = [deft: 2, defpt: 2, t: 1]
 
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
-locals_without_parens = [deft: 2, defpt: 2, t: 1]
+locals_without_parens = [deft: 2, defpt: 2, t: 1, t: 2]
 
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,5 +3,8 @@ import Config
 config :telemetria,
   events: [
     [:test, :telemetria, :example, :twice],
-    [:test, :telemetria, :example, :sum_with_doubled]
+    [:test, :telemetria, :example, :sum_with_doubled],
+    [:test, :telemetria, :example, :half],
+    [:test, :telemetria, :example, :half_named, :foo],
+    [:test, :telemetria, :example, :tmed]
   ]

--- a/lib/telemetria.ex
+++ b/lib/telemetria.ex
@@ -52,10 +52,9 @@ defmodule Telemetria do
   @spec do_t(ast, [atom()] | atom(), Macro.Env.t(), keyword()) :: ast
         when ast: {atom(), keyword(), tuple() | list()}
   defp do_t(ast, call, caller, context \\ []) do
-    case telemetry_wrap(ast, List.wrap(call), caller, context) do
-      [do: ast] -> ast
-      ast -> ast
-    end
+    ast
+    |> telemetry_wrap(List.wrap(call), caller, context)
+    |> Keyword.get(:do, [])
   end
 
   @compile {:inline, telemetry_prefix: 2}

--- a/test/support/telemetria_tester.ex
+++ b/test/support/telemetria_tester.ex
@@ -15,11 +15,11 @@ defmodule Test.Telemetria.Example do
 
   def half(a) do
     divider =
-      t(fn
+      t fn
         a when is_integer(a) -> a / 2
         {a, _, _} -> a
         _ -> nil
-      end)
+      end
 
     divider.(a)
   end

--- a/test/support/telemetria_tester.ex
+++ b/test/support/telemetria_tester.ex
@@ -12,4 +12,20 @@ defmodule Test.Telemetria.Example do
   deft sum_with_doubled(a1, a2) do
     a1 + twice(a2)
   end
+
+  def half(a) do
+    divider =
+      t(fn
+        a when is_integer(a) -> a / 2
+        _ -> nil
+      end)
+
+    divider.(a)
+  end
+
+  def half_named(a) do
+    t(&(&1 / 2), :foo).(a)
+  end
+
+  def tmed, do: t(21 + 21)
 end

--- a/test/support/telemetria_tester.ex
+++ b/test/support/telemetria_tester.ex
@@ -17,6 +17,7 @@ defmodule Test.Telemetria.Example do
     divider =
       t(fn
         a when is_integer(a) -> a / 2
+        {a, _, _} -> a
         _ -> nil
       end)
 

--- a/test/telemetria_test.exs
+++ b/test/telemetria_test.exs
@@ -4,7 +4,7 @@ defmodule Telemetria.Test do
   doctest Telemetria
   alias Test.Telemetria.Example
 
-  test "attaches telemetry events and spits out logs" do
+  test "attaches telemetry events to module functions and spits out logs" do
     log =
       capture_log(fn ->
         Example.sum_with_doubled(1, 3)
@@ -13,5 +13,35 @@ defmodule Telemetria.Test do
 
     assert log =~ "[:test, :telemetria, :example, :twice]"
     assert log =~ "[:test, :telemetria, :example, :sum_with_doubled]"
+  end
+
+  test "attaches telemetry events to anonymous local functions and spits out logs" do
+    log =
+      capture_log(fn ->
+        Example.half(4)
+        Process.sleep(100)
+      end)
+
+    assert log =~ "[:test, :telemetria, :example, :half]"
+  end
+
+  test "attaches telemetry events named and spits out logs" do
+    log =
+      capture_log(fn ->
+        Example.half_named(4)
+        Process.sleep(100)
+      end)
+
+    assert log =~ "[:test, :telemetria, :example, :half_named, :foo]"
+  end
+
+  test "attaches telemetry events to random ast and spits out logs" do
+    log =
+      capture_log(fn ->
+        Example.tmed()
+        Process.sleep(100)
+      end)
+
+    assert log =~ "[:test, :telemetria, :example, :tmed]"
   end
 end

--- a/test/telemetria_test.exs
+++ b/test/telemetria_test.exs
@@ -18,11 +18,12 @@ defmodule Telemetria.Test do
   test "attaches telemetry events to anonymous local functions and spits out logs" do
     log =
       capture_log(fn ->
-        Example.half(4)
+        Example.half(42)
         Process.sleep(100)
       end)
 
     assert log =~ "[:test, :telemetria, :example, :half]"
+    assert log =~ "arguments: [a: 42]"
   end
 
   test "attaches telemetry events named and spits out logs" do


### PR DESCRIPTION
Closes #5.

Features: `Telemetry.t/2` macro accepting any AST and optional suffix param for the event name.

When an anonymous function is wrapped, _each_ clause is wrapped separately and `arguments: ` key in `context` is filled with parameter names and values. Example:

```elixir
divider =
  t fn
    a when is_integer(a) -> a / 2
    {a, _, _} -> a
    _ -> nil
   end
```