### PR TITLE
Feature/#3 auto config

### DIFF
--- a/lib/instrumenter.ex
+++ b/lib/instrumenter.ex
@@ -4,13 +4,15 @@ defmodule Telemetria.Instrumenter do
   require Logger
   use Boundary, deps: [], exports: []
 
-  @otp_app Application.fetch_env!(:telemetria, :otp_app)
+  @json_config Telemetria.ConfigProvider.json_config!()
+
+  @otp_app Application.get_env(:telemetria, :otp_app, [])
   @spec otp_app :: binary()
-  def otp_app, do: to_string(@otp_app)
+  def otp_app, do: to_string(Keyword.get(@json_config, :otp_app, @otp_app))
 
   @events Application.fetch_env!(:telemetria, :events)
   @spec events :: [[atom()]]
-  def events, do: @events
+  def events, do: Enum.to_list(MapSet.new(Keyword.get(@json_config, :events, []) ++ @events))
 
   def setup do
     Application.stop(:telemetry)

--- a/lib/instrumenter.ex
+++ b/lib/instrumenter.ex
@@ -2,7 +2,7 @@ defmodule Telemetria.Instrumenter do
   @moduledoc false
 
   require Logger
-  use Boundary, deps: [], exports: []
+  use Boundary, deps: [Telemetria.ConfigProvider], exports: []
 
   @json_config Telemetria.ConfigProvider.json_config!()
 

--- a/lib/mix/config_provider.ex
+++ b/lib/mix/config_provider.ex
@@ -1,0 +1,42 @@
+defmodule Telemetria.ConfigProvider do
+  @behaviour Config.Provider
+
+  @impl Config.Provider
+  def init(path) when is_binary(path), do: path
+
+  @impl Config.Provider
+  def load(config, path) do
+    {:ok, _} = Application.ensure_all_started(:jason)
+
+    json = path |> File.read!() |> Jason.decode!()
+
+    Config.Reader.merge(
+      config,
+      telemetria: [
+        otp_app: json["otp_app"],
+        events: json["events"]
+      ]
+    )
+  end
+
+  @spec json_config!(binary()) :: keyword()
+  def json_config!(path \\ Path.join(["config", ".telemetria.config.json"])) do
+    path
+    |> File.exists?()
+    |> if do
+      with {:ok, json} <- File.read(path) do
+        json
+        |> Jason.decode!()
+        |> maybe_atomize()
+        |> Map.to_list()
+      end
+    end
+    |> Kernel.||([])
+  end
+
+  defp maybe_atomize(v) when is_binary(v), do: String.to_atom(v)
+  defp maybe_atomize({k, v}), do: {maybe_atomize(k), maybe_atomize(v)}
+  defp maybe_atomize(v) when is_list(v), do: Enum.map(v, &maybe_atomize/1)
+  defp maybe_atomize(v) when is_map(v), do: Enum.into(v, %{}, &maybe_atomize/1)
+  defp maybe_atomize(v), do: v
+end

--- a/lib/mix/config_provider.ex
+++ b/lib/mix/config_provider.ex
@@ -1,4 +1,8 @@
 defmodule Telemetria.ConfigProvider do
+  @moduledoc false
+
+  use Boundary, deps: [], exports: []
+
   @behaviour Config.Provider
 
   @impl Config.Provider

--- a/lib/mix/events.ex
+++ b/lib/mix/events.ex
@@ -1,9 +1,11 @@
 defmodule Telemetria.Mix.Events do
   @moduledoc false
 
+  use Boundary, deps: [], exports: []
+
   use Agent
 
-  def start_link(),
+  def start_link,
     do: Agent.start_link(fn -> %{events: %{}, diagnostics: MapSet.new()} end, name: __MODULE__)
 
   def all, do: Agent.get(__MODULE__, & &1)

--- a/lib/mix/events.ex
+++ b/lib/mix/events.ex
@@ -1,0 +1,27 @@
+defmodule Telemetria.Mix.Events do
+  @moduledoc false
+
+  use Agent
+
+  def start_link(),
+    do: Agent.start_link(fn -> %{events: %{}, modules: MapSet.new()} end, name: __MODULE__)
+
+  def all, do: Agent.get(__MODULE__, & &1)
+
+  def put(:event, {module, event}) do
+    Agent.update(
+      __MODULE__,
+      &update_in(&1, [:events, module], fn
+        nil -> MapSet.new([event])
+        events -> MapSet.put(events, event)
+      end)
+    )
+  end
+
+  def put(:module, module),
+    do:
+      Agent.update(
+        __MODULE__,
+        &Map.update!(&1, :modules, fn modules -> MapSet.put(modules, module) end)
+      )
+end

--- a/lib/mix/events.ex
+++ b/lib/mix/events.ex
@@ -4,7 +4,7 @@ defmodule Telemetria.Mix.Events do
   use Agent
 
   def start_link(),
-    do: Agent.start_link(fn -> %{events: %{}, modules: MapSet.new()} end, name: __MODULE__)
+    do: Agent.start_link(fn -> %{events: %{}, diagnostics: MapSet.new()} end, name: __MODULE__)
 
   def all, do: Agent.get(__MODULE__, & &1)
 
@@ -18,10 +18,10 @@ defmodule Telemetria.Mix.Events do
     )
   end
 
-  def put(:module, module),
+  def put(:diagnostic, diagnostic),
     do:
       Agent.update(
         __MODULE__,
-        &Map.update!(&1, :modules, fn modules -> MapSet.put(modules, module) end)
+        &Map.update!(&1, :diagnostics, fn diagnostics -> MapSet.put(diagnostics, diagnostic) end)
       )
 end

--- a/lib/mix/tasks/compile/telemetria.ex
+++ b/lib/mix/tasks/compile/telemetria.ex
@@ -4,6 +4,9 @@ defmodule Mix.Tasks.Compile.Telemetria do
   use Boundary, deps: [], exports: []
   use Mix.Task.Compiler
   alias Mix.Task.Compiler
+  alias Telemetria.Mix.Events
+
+  @preferred_cli_env :dev
 
   @moduledoc """
   Allows compile-time telemetry events definition.
@@ -31,9 +34,35 @@ defmodule Mix.Tasks.Compile.Telemetria do
   @impl Compiler
   def run(argv) do
     :ok = Application.ensure_started(:telemetry)
+    Events.start_link()
+
     Compiler.after_compiler(:app, &after_compiler(&1, argv))
-    {:ok, []}
+
+    tracers = Code.get_compiler_option(:tracers)
+    Code.put_compiler_option(:tracers, [__MODULE__ | tracers])
+
+    {:ok, [diagnostic("hey there")]}
   end
+
+  @manifest_events "telemetria_events"
+
+  @impl Compiler
+  def manifests, do: [manifest_path(@manifest_events)]
+
+  @impl Compiler
+  def clean do
+    :ok
+  end
+
+  @doc false
+  # def trace({remote, _meta, Telemetria, _name, _arity}, _env)
+  def trace({remote, meta, Telemetria, _name, _arity}, env)
+      when remote in ~w/remote_macro imported_macro/a do
+    Events.put(:module, {env.module, meta})
+    :ok
+  end
+
+  def trace(_event, _env), do: :ok
 
   defp after_compiler({:error, _} = status, _argv), do: status
 
@@ -44,7 +73,92 @@ defmodule Mix.Tasks.Compile.Telemetria do
     Application.unload(app_name)
     Application.load(app_name)
 
-    Mix.Shell.IO.info("Telemetry events registered: ...")
-    {status, diagnostics}
+    tracers = Enum.reject(Code.get_compiler_option(:tracers), &(&1 == __MODULE__))
+    Code.put_compiler_option(:tracers, tracers)
+
+    %{events: events, modules: _modules} = Events.all()
+
+    [full, added, removed] =
+      @manifest_events
+      |> read_manifest()
+      |> case do
+        nil ->
+          [events, events, %{}]
+
+        old ->
+          {related, rest} = Map.split(old, Map.keys(events))
+          related_old = MapSet.new(Enum.flat_map(related, &elem(&1, 1)))
+          related_new = MapSet.new(Enum.flat_map(events, &elem(&1, 1)))
+
+          [
+            Map.merge(rest, events),
+            MapSet.difference(related_new, related_old),
+            MapSet.difference(related_old, related_new)
+          ]
+      end
+
+    write_manifest(@manifest_events, full)
+
+    [added, removed]
+    |> Enum.map(&Enum.map(&1, fn m -> inspect(m, limit: :infinity) end))
+    |> case do
+      [[], []] ->
+        Mix.shell().info("Telemetry events were not updated")
+
+      [[], rem] ->
+        Mix.shell().info(Enum.join(["Telemetry events removed:" | rem], "\n  - "))
+
+      [add, []] ->
+        Mix.shell().info(Enum.join(["Telemetry events added:  " | add], "\n  - "))
+
+      [add, rem] ->
+        Mix.shell().info(
+          "Telemetry events:\n" <>
+            Enum.join(["  - added:" | add], "\n    - ") <>
+            Enum.join(["  - removed:" | rem], "\n    - ")
+        )
+    end
+
+    {status, diagnostics ++ [diagnostic("hey there")]}
+  end
+
+  defp diagnostic(message, opts \\ []) do
+    %Mix.Task.Compiler.Diagnostic{
+      compiler_name: "telemetria",
+      details: nil,
+      file: "unknown",
+      message: message,
+      position: nil,
+      severity: :information
+    }
+    |> Map.merge(Map.new(opts))
+  end
+
+  @spec manifest_path(binary()) :: binary()
+  def manifest_path(name),
+    do: Mix.Project.config() |> Mix.Project.manifest_path() |> Path.join("compile.#{name}")
+
+  @spec stale_manifest?(binary()) :: boolean()
+  def stale_manifest?(name),
+    do: Mix.Utils.stale?([Mix.Project.config_mtime()], [manifest_path(name)])
+
+  @spec read_manifest(binary()) :: term()
+  def read_manifest(name) do
+    unless stale_manifest?(name) do
+      name
+      |> manifest_path()
+      |> File.read()
+      |> case do
+        {:ok, manifest} -> :erlang.binary_to_term(manifest)
+        _ -> nil
+      end
+    end
+  end
+
+  @spec write_manifest(binary(), term()) :: :ok
+  def write_manifest(name, data) do
+    path = manifest_path(name)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, :erlang.term_to_binary(data))
   end
 end

--- a/lib/mix/tasks/compile/telemetria.ex
+++ b/lib/mix/tasks/compile/telemetria.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Compile.Telemetria do
   # credo:disable-for-this-file Credo.Check.Readability.Specs
 
-  use Boundary, deps: [], exports: []
+  use Boundary, deps: [Telemetria.Mix.Events], exports: []
   use Mix.Task.Compiler
   alias Mix.Task.Compiler
   alias Telemetria.Mix.Events
@@ -136,10 +136,14 @@ defmodule Mix.Tasks.Compile.Telemetria do
         Mix.shell().info("Telemetry events were not updated")
 
       [[], rem] ->
-        Mix.shell().info(Enum.join(["Telemetry events removed:" | rem], "\n  - "))
+        ["Telemetry events removed:" | rem]
+        |> Enum.join("\n  - ")
+        |> Mix.shell().info()
 
       [add, []] ->
-        Mix.shell().info(Enum.join(["Telemetry events added:  " | add], "\n  - "))
+        ["Telemetry events added:  " | add]
+        |> Enum.join("\n  - ")
+        |> Mix.shell().info()
 
       [add, rem] ->
         Mix.shell().info(

--- a/lib/telemetria.ex
+++ b/lib/telemetria.ex
@@ -3,7 +3,9 @@ defmodule Telemetria do
   Declares helpers to define functions with telemetria attached.
   """
 
-  use Boundary, deps: [Telemetria.Instrumenter], exports: []
+  use Boundary, deps: [Telemetria.Instrumenter, Telemetria.Mix.Events], exports: []
+
+  alias Telemetria.Mix.Events
 
   defmodule Handler do
     @moduledoc "Default handler used unless the custom one is specified in config"
@@ -135,7 +137,7 @@ defmodule Telemetria do
   end
 
   defp report(event, caller) do
-    if is_nil(GenServer.whereis(Telemetria.Mix.Events)) do
+    if is_nil(GenServer.whereis(Events)) do
       Mix.shell().info([
         [:bright, :green, "[INFO] ", :reset],
         "Added event: #{inspect(event)} at ",
@@ -148,7 +150,7 @@ defmodule Telemetria do
         "Add `:telemetria` compiler to `compilers:` in your `mix.exs`!"
       ])
     else
-      Telemetria.Mix.Events.put(:event, {caller.module, event})
+      Events.put(:event, {caller.module, event})
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,7 @@ defmodule Telemetria.MixProject do
     [
       {:boundary, "~> 0.4", runtime: false},
       {:telemetry, "~> 0.4"},
+      {:jason, "~> 1.0"},
       {:nimble_options, "~> 0.2"},
       # dev / test
       {:dialyxir, "~> 1.0.0", only: [:dev, :test, :ci]},


### PR DESCRIPTION
In this PR:

- [x] compiler for `:telemetria` taking care about partial compilations, storing the full list of events in the compiler manifest file _and_ exporting the events to JSON config available later from config provider
- [x] config provider for JSON config (useful for releases)
- [x] full diagnostics of `:telemetria` usages are provided to core _Elixir_ compiler
- [x] incremental compilation support
- [x] without compiler added to the list of target compilers, spits the events out _and_ prints warning