### PR TITLE
Result is returned.

### DIFF
--- a/lib/telemetria.ex
+++ b/lib/telemetria.ex
@@ -208,7 +208,7 @@ defmodule Telemetria do
     unless is_nil(caller.module),
       do: Module.put_attribute(caller.module, :doc, {caller.line, telemetry: true})
 
-    caller = Macro.escape(caller)
+    caller = Macro.escape(Map.take(caller, ~w|file line|a))
 
     block =
       quote do
@@ -230,7 +230,7 @@ defmodule Telemetria do
             system_time: now,
             consumed: benchmark
           },
-          %{env: unquote(caller), context: unquote(context)}
+          %{env: unquote(caller), result: result, context: unquote(context)}
         )
 
         result

--- a/test/telemetria_test.exs
+++ b/test/telemetria_test.exs
@@ -13,6 +13,7 @@ defmodule Telemetria.Test do
 
     assert log =~ "[:test, :telemetria, :example, :twice]"
     assert log =~ "[:test, :telemetria, :example, :sum_with_doubled]"
+    assert log =~ "result: 7"
   end
 
   test "attaches telemetry events to anonymous local functions and spits out logs" do
@@ -24,6 +25,7 @@ defmodule Telemetria.Test do
 
     assert log =~ "[:test, :telemetria, :example, :half]"
     assert log =~ "arguments: [a: 42]"
+    assert log =~ "result: 21"
   end
 
   test "attaches telemetry events named and spits out logs" do
@@ -34,6 +36,7 @@ defmodule Telemetria.Test do
       end)
 
     assert log =~ "[:test, :telemetria, :example, :half_named, :foo]"
+    assert log =~ "result: #Function<"
   end
 
   test "attaches telemetry events to random ast and spits out logs" do
@@ -44,6 +47,7 @@ defmodule Telemetria.Test do
       end)
 
     assert log =~ "[:test, :telemetria, :example, :tmed]"
+    assert log =~ "result: 42"
   end
 
   test "attaches telemetry events to random ast with do-end syntax and spits out logs" do
@@ -54,6 +58,7 @@ defmodule Telemetria.Test do
       end)
 
     assert log =~ "[:test, :telemetria, :example, :tmed_do]"
+    assert log =~ "result: 42"
   end
 
   test "attaches telemetry events to guarded function and spits out logs" do
@@ -65,6 +70,8 @@ defmodule Telemetria.Test do
       end)
 
     assert log =~ "[:test, :telemetria, :example, :guarded]"
+    assert log =~ "result: 84"
+    assert log =~ "result: :ok"
   end
 
   test "@telemetry true" do
@@ -76,5 +83,6 @@ defmodule Telemetria.Test do
 
     assert log =~ "[:test, :telemetria, :example, :annotated_1]"
     assert log =~ "[:test, :telemetria, :example, :annotated_2]"
+    assert log =~ "result: 42"
   end
 end


### PR DESCRIPTION
Closes #15.

Args are not returned because it would require too much intervention in the original AST. Wrap anonymous function `t(arg -> res)` to get arguments.