### PR TITLE
Total cleanup

### DIFF
--- a/lib/telemetria/handler.ex
+++ b/lib/telemetria/handler.ex
@@ -16,4 +16,42 @@ defmodule Telemetria.Handler do
               :telemetry.event_metadata(),
               :telemetry.handler_config()
             ) :: :ok
+
+  @type process_info :: [
+          {:status, atom()}
+          | {:message_queue_len, any()}
+          | {:priority, any()}
+          | {:total_heap_size, any()}
+          | {:heap_size, any()}
+          | {:stack_size, any()}
+          | {:reductions, any()}
+          | {:garbage_collection,
+             [
+               {:fullsweep_after, non_neg_integer()}
+               | {:max_heap_size,
+                  %{error_logger: boolean(), kill: boolean(), size: non_neg_integer()}}
+               | {:min_bin_vheap_size, non_neg_integer()}
+               | {:min_heap_size, non_neg_integer()}
+               | {:minor_gcs, non_neg_integer()}
+             ]}
+          | {:schedulers, non_neg_integer()}
+        ]
+  @spec process_info(pid :: nil | pid()) :: process_info()
+  @doc "Collects and formats the current process info to insert to metadata"
+  def process_info(pid \\ nil) do
+    (pid || self())
+    |> Process.info()
+    |> Kernel.||([])
+    |> Keyword.take([
+      :status,
+      :message_queue_len,
+      :priority,
+      :total_heap_size,
+      :heap_size,
+      :stack_size,
+      :reductions,
+      :garbage_collection
+    ])
+    |> Keyword.put(:schedulers, System.schedulers())
+  end
 end

--- a/lib/telemetria/module_hooks.ex
+++ b/lib/telemetria/module_hooks.ex
@@ -24,7 +24,7 @@ defmodule Telemetria.Hooks do
   end
 
   @typedoc false
-  @type option :: {:level, level()} | {:inspect, Inspect.Opts.t()} | {atom(), any()}
+  @type option :: {:level, level()} | {:inspect_opts, Inspect.Opts.t()} | {atom(), any()}
   @typedoc false
   @type info :: %{
           env: Macro.Env.t(),
@@ -87,7 +87,14 @@ defmodule Telemetria.Hooks do
       hooks
       |> Enum.map(fn info ->
         meta = info.env
-        head = maybe_guarded(info.guards, info.fun, [file: meta.file, line: meta.line], info.args)
+
+        head =
+          maybe_guarded(
+            info.guards,
+            info.fun,
+            [module: meta.module, function: meta.function, file: meta.file, line: meta.line],
+            info.args
+          )
 
         body =
           Telemetria.telemetry_wrap(info.body, {info.fun, [line: meta.line], info.args}, meta,

--- a/test/telemetria_formatter_test.exs
+++ b/test/telemetria_formatter_test.exs
@@ -37,7 +37,7 @@ defmodule Telemetria.FormatterTest do
       end)
 
     assert log =~ ~s|[\"test\",\"telemetria\",\"example\",\"half\"]|
-    assert log =~ ~s|\"arguments\":{\"a\":42}|
+    assert log =~ ~s|\"args\":{\"a\":42}|
     assert log =~ ~s|\"result\":21|
   end
 
@@ -106,8 +106,8 @@ defmodule Telemetria.FormatterTest do
         Process.sleep(100)
       end)
 
-    assert log =~ ~s|name\":[\"test\",\"telemetria\",\"example\",\"annotated_1\"]|
-    assert log =~ ~s|name\":[\"test\",\"telemetria\",\"example\",\"annotated_2\"]|
+    assert log =~ ~s|event\":[\"test\",\"telemetria\",\"example\",\"annotated_1\"]|
+    assert log =~ ~s|event\":[\"test\",\"telemetria\",\"example\",\"annotated_2\"]|
     assert log =~ ~s|\"result\":42|
   end
 end

--- a/test/telemetria_test.exs
+++ b/test/telemetria_test.exs
@@ -29,7 +29,7 @@ defmodule Telemetria.Test do
       end)
 
     assert log =~ "[:test, :telemetria, :example, :half]"
-    assert log =~ "arguments: [a: 42]"
+    assert log =~ "args: [a: 42]"
     assert log =~ "result: 21"
   end
 
@@ -98,8 +98,8 @@ defmodule Telemetria.Test do
         Process.sleep(100)
       end)
 
-    assert log =~ "name: [:test, :telemetria, :example, :annotated_1]"
-    assert log =~ "name: [:test, :telemetria, :example, :annotated_2]"
+    assert log =~ "event: [:test, :telemetria, :example, :annotated_1]"
+    assert log =~ "event: [:test, :telemetria, :example, :annotated_2]"
     assert log =~ "result: 42"
   end
 
@@ -112,6 +112,6 @@ defmodule Telemetria.Test do
         Process.sleep(100)
       end)
 
-    assert log =~ "name: [:test, :telemetria, :example, :check_s]"
+    assert log =~ "event: [:test, :telemetria, :example, :check_s]"
   end
 end


### PR DESCRIPTION
- [x] `@telemetria process_info: true` keyword parameter
- [x] `@id` is set to the correct `otp_app`
- [x] MFA is set properly for alerts
- [x] arguments and result are grouped under `:call` 
- [x] total metadata cleanup

The event, deserialized, with `process_info: true`
```elixir
%{
  "@id" => "telemetria_test",
  "@timestamp" => "2020-07-15T09:23:14.585Z",
  "@type" => "metrics",
  "application" => "telemetria",
  "domain" => ["elixir"],
  "file" => "/home/am/Proyectos/Elixir/telemetria_test/lib/telemetria_test.ex",
  "function" => "&Geom.circle_len/1",
  "gl" => "<0.67.0>",
  "line" => 23,
  "message" => "",
  "mfa" => ["Elixir.Telemetria.Handler.Default", "do_log", 3],
  "module" => "Elixir.Geom",
  "pid" => "<0.325.0>",
  "process_info" => %{
    "garbage_collection" => %{
      "fullsweep_after" => 65535,
      "max_heap_size" => %{
        "error_logger" => "true",
        "kill" => "true",
        "size" => 0
      },
      "min_bin_vheap_size" => 46422,
      "min_heap_size" => 233,
      "minor_gcs" => 5 
    },
    "heap_size" => 2586,
    "message_queue_len" => 0,
    "priority" => "normal",
    "reductions" => 7989,
    "schedulers" => 12,
    "stack_size" => 84,
    "status" => "running",
    "total_heap_size" => 6777
  },
  "severity" => "warn",
  "telemetria" => %{
    "call" => %{"args" => %{"radius" => 1}, "result" => 6.28},
    "config" => "<0.321.0>",
    "context" => %{"foo" => "bar"},
    "event" => ["geom", "circle_len"],
    "measurements" => %{
      "consumed" => 9,
      "reference" => "#Reference<0.4289730586.489422855.117201>",
      "system_time" => %{
        "monotonic" => -576460749893289,
        "system" => 1594797794585865766,
        "utc" => "2020-07-15T07:23:14.585866Z"
      }
    },
    "name" => "geom.circle_len"
  },
  "time" => 1594797794585956
}
```