### PR TITLE
Allow `[transform: [args: M.f/1, result: {M, :f}]]` argument

### DIFF
--- a/test/support/telemetria_tester.ex
+++ b/test/support/telemetria_tester.ex
@@ -52,7 +52,11 @@ defmodule Test.Telemetria.Example do
   @telemetria level: :debug
   defp annotated_2(nil), do: 0
 
-  @telemetria level: :warn
+  @telemetria level: :warn,
+              transform: [
+                args: {__MODULE__, :transform_args},
+                result: &__MODULE__.transform_result/1
+              ]
   defp annotated_2(i) when (is_integer(i) and i == 42) or is_nil(i), do: i || 42
 
   @telemetria level: :error
@@ -78,4 +82,9 @@ defmodule Test.Telemetria.Example do
   def check_s(%Test.Telemetria.S{bar: :baz}), do: {:ok, :bar}
   @telemetria true
   def check_s(any), do: {:error, any}
+
+  #############################################################################
+  def transform_args(args), do: inspect(args)
+
+  def transform_result(result), do: inspect(result)
 end

--- a/test/telemetria_test.exs
+++ b/test/telemetria_test.exs
@@ -102,10 +102,13 @@ defmodule Telemetria.Test do
 
     assert log =~ "event: [:test, :telemetria, :example, :annotated_1]"
     assert log =~ "event: [:test, :telemetria, :example, :annotated_2]"
-    assert log =~ "result: 42"
-    assert log =~ "[info]"
-    assert log =~ "[error]"
     refute log =~ "[debug]"
+    assert log =~ "[info]"
+    assert log =~ ~s|call: [args: [foo: 42], result: 42]|
+    assert log =~ "[warning]"
+    assert log =~ ~s|call: [args: "[i: 42]", result: "42"]|
+    assert log =~ "[error]"
+    assert log =~ ~s|call: [args: [i: "42"], result: :forty_two]|
   end
 
   test "@telemetry deep pattern match" do


### PR DESCRIPTION
Another argument to `@telemetria` call.

This PR closes #29.